### PR TITLE
Rename lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# jetbrains
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python: 3.6
 cache: pip
+env:
+  - REPO_NAME="${PWD##*/}"
 install:
   - pip install pipenv
   - pipenv install --dev
@@ -29,14 +31,12 @@ jobs:
         - |
           sam package --template-file .aws-sam/build/template.yaml \
             --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw \
-            --output-template-file .aws-sam/build/my-lambda.yaml
+            --output-template-file .aws-sam/build/$REPO_NAME.yaml
     - stage: deploy
-      env:
-        - REPO_NAME="${PWD##*/}"
       script:
         - sam build
         - |
           sam package --template-file .aws-sam/build/template.yaml \
             --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw \
-            --output-template-file .aws-sam/build/my-lambda.yaml
+            --output-template-file .aws-sam/build/$REPO_NAME.yaml
         - aws s3 cp .aws-sam/build/template.yaml s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/$REPO_NAME/$TRAVIS_BRANCH

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This requires the correct permissions to upload to bucket
 ```shell script
 sam package --template-file .aws-sam/build/template.yaml \
   --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw \
-  --output-template-file .aws-sam/build/my-lambda.yaml
+  --output-template-file .aws-sam/build/lambda-template.yaml
 
 aws s3 cp .aws-sam/build/template.yaml s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/my-lambda-repo/master
 ```
@@ -64,9 +64,9 @@ aws s3 cp .aws-sam/build/template.yaml s3://bootstrap-awss3cloudformationbucket-
 ## Install Lambda into AWS
 Create the following [sceptre](https://github.com/Sceptre/sceptre) file
 
-config/prod/my-lambda.yaml
+config/prod/lambda-template.yaml
 ```yaml
-template_path: "remote/my-lambda.yaml"
+template_path: "remote/lambda-template.yaml"
 stack_name: "my-lambda"
 stack_tags:
   Department: "Platform"
@@ -74,7 +74,7 @@ stack_tags:
   OwnerEmail: "it@sagebase.org"
 hooks:
   before_launch:
-    - !cmd "curl https://s3.amazonaws.com/essentials-awss3lambdaartifactsbucket-x29ftznj6pqw/my-lambda-repo/master/my-lambda.yaml --create-dirs -o templates/remote/my-lambda.yaml"
+    - !cmd "curl https://s3.amazonaws.com/essentials-awss3lambdaartifactsbucket-x29ftznj6pqw/my-lambda-repo/master/lambda-template.yaml --create-dirs -o templates/remote/lambda-template.yaml"
 ```
 
 Install the lambda using sceptre:

--- a/template.yaml
+++ b/template.yaml
@@ -1,9 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  my-lambda
-
-  Sample SAM Template for my-lambda
+  Hello World lambda
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
@@ -17,6 +15,7 @@ Resources:
       CodeUri: hello_world/
       Handler: app.lambda_handler
       Runtime: python3.6
+      Role: !GetAtt FunctionRole.Arn
       Events:
         HelloWorld:
           Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
@@ -24,6 +23,33 @@ Resources:
             Path: /hello
             Method: get
 
+  FunctionRole:   # execute lambda function with this role
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Ref LogsPolicy
+
+  LogsPolicy:     # policy to allow lambda to write logs to cloudwatch
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: "*"
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
   # Find out more about other implicit resources you can reference within SAM


### PR DESCRIPTION
As a convention we usually like to give the lambda the same name
as the repo and deploy it with that name.  This makes it easier
to track deployed artifact back to the source.