### PR TITLE
update CFN transform naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A template for quickly starting a new AWS lambda project.
 ## Naming
 Naming conventions:
 * for a vanilla Lambda: `lambda-<context>`
-* for a Cloudformation Transform macro: `cfn-transform-<context>`
+* for a Cloudformation Transform macro: `cfn-macro-<context>`
 * for a Cloudformation Custom Resource: `cfn-cr-<context>`
 
 ## Development


### PR DESCRIPTION
I thought a transform and a macro were the same thing which they really are.  I've re-read the AWS documentation on CFN transform and macros a little more carefully and came to the conclusion that AWS describes a macro as an instance of a transform.  Also the AWS how to docs focus on the word macro more than transform.  In a sense we are really creating `macros` so updating the naming convention to be more appropriate.