### PR TITLE
Setup for multiple functions in one lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -26,8 +26,8 @@ Resources:
   HelloWorldFunction:
     Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
     Properties:
-      CodeUri: hello_world/
-      Handler: app.lambda_handler
+      CodeUri: .
+      Handler: hello_world/app.lambda_handler
       Runtime: python3.7
       Role: !GetAtt FunctionRole.Arn
       Events:


### PR DESCRIPTION
Setup repo to build lambda with multiple functions.
The only way to setup multiple functions in one lambda is to
move requirements.txt to the root and specify the src folder in
the CFN Handler parameter instead of CodeUri parameter.