### PR TITLE
Lint the generated template

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,4 +33,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/sam-build
-      - run: sam validate --lint
+      - run: sam validate --lint --template .aws-sam/build/template.yaml


### PR DESCRIPTION
By default sam-cli will validate the user-defined template, validate the processed template instead.