### PR TITLE
[IT-3146] Periodically run unit tests

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -6,5 +6,6 @@ on:
     - cron: '30 16 15 * *'  # 16:30 UTC (9:30 PST) on the 15th of the month
 
 jobs:
-  lambda-test:
+  # Check that our current dependencies still work
+  dependency-check:
     uses: "./.github/workflows/test.yaml"

--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -1,0 +1,10 @@
+name: periodic
+
+on:
+  # Run once a month
+  schedule:
+    - cron: '30 16 15 * *'  # 16:30 UTC (9:30 PST) on the 15th of the month
+
+jobs:
+  lambda-test:
+    uses: "./.github/workflows/test.yaml"


### PR DESCRIPTION
Run the unit tests once a month to validate that our dependencies still work.
